### PR TITLE
handle custom download

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,8 +3,9 @@
 var constants = {
   platform: {
     id: 'msteams',
-    name: 'MSTeams Platform Template'
-  }
+    name: 'MSTeams Platform Template',
+  },
+  IMG_GEN_OUT_DATAURI: 'data:image/png;base64,',
 };
 
 module.exports = constants;

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -83,14 +83,13 @@ function convertFromBase(manifestInfo, callback) {
     for (var j = 0; j < originalManifest.icons.length; j++) {
       var icon = originalManifest.icons[j];
       var size = ['32x32', '192x192'].indexOf(icon.sizes); //specify which size icons from manifest to keep
-    if(size >=0){
-        if (icon.sizes == '32x32') {
-          icons.outline = icon.src;
-        } else if (icon.sizes == '192x192') {
-          icons.color = icon.src;
-        }
-    }
-
+      if(size >=0){
+          if (icon.sizes == '32x32') {
+            icons.outline = icon.src;
+          } else if (icon.sizes == '192x192') {
+            icons.color = icon.src;
+          }
+      }
     }
     manifest.icons = icons;
   }

--- a/lib/msteams-utils.js
+++ b/lib/msteams-utils.js
@@ -5,7 +5,12 @@ var sizeOf = require('image-size');
 function parseMsTeamsSchema(options, manifest) {
   // Load passed json string parameter into the manifest, will throw exception in cli path atm.
   try {
-    var schema = options && options.schema && JSON.parse(options.schema);
+    var schema;
+    if (options && options.schema && typeof options.schema === "object") {
+      schema = options.schema;
+    } else if (options && typeof options.schema === "string") {
+      schema = JSON.parse(options.schema);
+    }
     var msTeamsSchemaParams = schema && schema.msteams;
 
     manifest.content.developer.name = msTeamsSchemaParams.publisherName;
@@ -13,7 +18,7 @@ function parseMsTeamsSchema(options, manifest) {
     manifest.content.description.short = msTeamsSchemaParams.shortDescription;
     manifest.content.developer.privacyUrl = msTeamsSchemaParams.privacyUrl;
     manifest.content.developer.termsOfUseUrl = msTeamsSchemaParams.termsOfUseUrl;
-  } catch (e) { }
+  } catch (e) {}
 }
 
 function resolveImagePaths(manifest, rootDir, imagesDir) {

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -159,6 +159,128 @@ function Platform (packageName, platforms) {
 
       .nodeify(callback);
   };
+
+  /*
+    Overwritten downloadIcons
+      Follows the same path as the manifest, works with the outputManifest to determine which icons need to be downloaded, but refers to the originalManifest to do the rest.
+      Use original manifest to keep the type of the
+  */
+  self.downloadIcons = function (originalManifest, outputManifest, baseUrl, imagesOutputInfo, callback) {
+    self.debug('Downloading the ' + self.id + ' icons...');
+
+    // defaults for images output folder and manifest icons' path updates
+    var rootDir = imagesOutputInfo;
+    var imagesDir = imagesOutputInfo;
+    var relativePath = '';
+    var updatePaths = false;
+
+    // if the imagesOutputInfo is object with content
+    if (imagesOutputInfo.rootFolder) {
+      self.debug('Overriding defaults with custom images info: ' + JSON.stringify(imagesOutputInfo));
+
+      rootDir = imagesOutputInfo.rootFolder;
+      imagesDir = imagesOutputInfo.outputFolder;
+      relativePath = imagesOutputInfo.relativePath;
+      updatePaths = imagesOutputInfo.updatePaths;
+    }
+
+    // download the icons specified in the manifest
+    var iconList = originalManifest.icons;
+    self.debug("icons: " + JSON.stringify(iconList));
+    return Q.resolve().then(function () {
+      if (iconList) {
+        var icons = self.getManifestIcons(originalManifest, outputManifest);
+        self.debug("icons: " + JSON.stringify(icons));
+
+        var downloadTasks = icons.map(function(icon) {
+          self.debug("icon: " + JSON.stringify(icon));
+
+          var isDataUri = new RegExp('^' + constants.IMG_GEN_OUT_DATAURI);
+          if (self.getEmbeddedIconUri(originalManifest, icon).match(isDataUri)) {
+            return self.resolveEmbeddedIcon(originalManifest, outputManifest, icon, rootDir, imagesDir);
+          }
+
+          var iconPath = icon.url || icon;
+          var iconUrl = url.resolve(baseUrl, iconPath);
+          var pathname = icon.fileName || url.parse(iconUrl).pathname;
+          var iconFilePath = path.join(imagesDir, pathname);
+          return iconTools.getIcon(iconUrl, iconFilePath);
+        });
+
+        return Q.allSettled(downloadTasks).then(function (results) {
+          results.forEach(function (result) {
+            if (result.state === 'rejected') {
+              self.warn('Error downloading an icon file. ' + result.reason.message);
+            }
+          });
+        });
+      }
+    }).then(function () { // copy default platform icons to replace any missing icons
+      // if the platform provided the input w3c manifest then remove it as it's no longer needed
+      delete(originalManifest.__w3cManifestInfo);
+
+      var defaultImagesDir = path.join(self.baseDir, 'assets', 'images');
+      return fileTools.syncFiles(defaultImagesDir, imagesDir, {
+        // filter out default images that do not need to be moved over
+        filter: function (file) {
+          // determine the icon dimensions assuming a convention where
+          // the file name specifies the icon's size (e.g. '50x50.png')
+          var size = path.basename(file, path.extname(file));
+          return !self.getManifestIcon(originalManifest, size);
+        }
+      }).then(function (files) {
+        files.forEach(function (file) {
+          // make path relative to imagesDir
+          var filePath = path.relative(imagesDir, file);
+
+          // convention is for file name to specify the icon's size
+          var size = path.basename(file, path.extname(file));
+          self.addManifestIcon(outputManifest, filePath, size);
+        });
+      })
+      .catch(function (err) {
+        if (err.code !== 'ENOENT') {
+          return Q.reject(err);
+        }
+
+        self.debug('No default icons were found to copy for the \'' + self.id + '\' platform.');
+      });
+    }).then(function() {
+      if (!updatePaths) { return; }
+
+      return self.updateManifestIconsPaths(outputManifest, relativePath);
+    }).nodeify(callback);
+  }
+
+  /*
+    using the resources of the original manifest, fetches file, preserves path, and then modifies the entry into the outputManifest
+  */
+  self.resolveEmbeddedIcon = function(originalManifest, outputManifest, iconFromGetManifestIcons, rootDir, imagesDir, callback) {
+    self.debug('resolveEmbeddedIcon() - iconFromGetManifestIcons: ' + JSON.stringify(iconFromGetManifestIcons));
+
+    self.debug('Getting embedded icon from ' + self.getEmbeddedIconUri(originalManifest, iconFromGetManifestIcons).substr(0, 50) + '...');
+
+    var targetFilename = self.getEmbeddedIconFilename(originalManifest, iconFromGetManifestIcons);
+    var outputFilename = path.join(imagesDir, targetFilename);
+    return fileTools.mkdirp(path.dirname(outputFilename)).then(function() {
+      var image = new Buffer(
+        self.getEmbeddedIconUri(originalManifest, iconFromGetManifestIcons).replace(constants.IMG_GEN_OUT_DATAURI, ''),
+        'base64');
+
+      self.debug('Writing embedded icon file to ' + outputFilename);
+      return Q.nfcall(fs.writeFile, outputFilename, image).then(function() {
+        return self.updateEmbeddedIconUri(outputManifest, iconFromGetManifestIcons, url.parse(targetFilename).pathname);
+      });
+    }).nodeify(callback);
+  };
+
+  /*
+    getManifestIcons
+    Overwritten because the outputManifest determines the keys, but the originalManifest provides the context object required to parse.
+   */
+  self.getManifestIcons = function (originalManifest, outputManifest) {
+    return Object.keys(outputManifest.icons || {}).map(function (size) { return originalManifest.icons[size]; });
+  };
 }
 
 util.inherits(Platform, PlatformBase);

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -212,7 +212,7 @@ function Platform (packageName, platforms) {
             return self.resolveEmbeddedIcon(originalManifest, outputManifest, icon, rootDir, imagesDir);
           }
 
-          var iconPath = icon.url || icon;
+          var iconPath = icon.url || icon.src || icon;
           var iconUrl = url.resolve(baseUrl, iconPath);
           var pathname = icon.fileName || url.parse(iconUrl).pathname;
           var iconFilePath = path.join(imagesDir, pathname);

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -57,6 +57,7 @@ function Platform (packageName, platforms) {
       // if the platform dir doesn't exist, create it
       .then(function (manifestInfo) {
         platformManifestInfo = manifestInfo;
+        // ignore icons output in the converted base... overload it at a later place in time.
         msteamsUtils.parseMsTeamsSchema(options, platformManifestInfo);
 
         self.debug('Creating the ' + constants.platform.name + ' app folder...');
@@ -72,9 +73,7 @@ function Platform (packageName, platforms) {
         return fileTools.mkdirp(imagesDir);
       })
       // download icons to the app's folder
-      .then(function () {
-        return self.downloadIcons(platformManifestInfo.content, w3cManifestInfo.content.start_url, imagesDir);
-      })
+      .then(function () { return self.downloadIcons(w3cManifestInfo.content, platformManifestInfo.content, w3cManifestInfo.content.start_url, imagesDir); })
       // Flatten the images directory structure
       .then(function () {
         self.debug('flattening the images folder');
@@ -186,15 +185,12 @@ function Platform (packageName, platforms) {
 
     // download the icons specified in the manifest
     var iconList = originalManifest.icons;
-    self.debug("icons: " + JSON.stringify(iconList));
     return Q.resolve().then(function () {
       if (iconList) {
         var icons = self.getManifestIcons(originalManifest, outputManifest);
         self.debug("icons: " + JSON.stringify(icons));
 
         var downloadTasks = icons.map(function(icon) {
-          self.debug("icon: " + JSON.stringify(icon));
-
           var isDataUri = new RegExp('^' + constants.IMG_GEN_OUT_DATAURI);
           if (self.getEmbeddedIconUri(originalManifest, icon).match(isDataUri)) {
             return self.resolveEmbeddedIcon(originalManifest, outputManifest, icon, rootDir, imagesDir);
@@ -279,7 +275,8 @@ function Platform (packageName, platforms) {
     Overwritten because the outputManifest determines the keys, but the originalManifest provides the context object required to parse.
    */
   self.getManifestIcons = function (originalManifest, outputManifest) {
-    return Object.keys(outputManifest.icons || {}).map(function (size) { return originalManifest.icons[size]; });
+    var values = Object.values(outputManifest.icons);
+    return originalManifest.icons.filter(entry => values.indexOf(entry.src) !== -1)
   };
 }
 


### PR DESCRIPTION
1. the default code path for data uris is broken (it looks at the wrong property for json objects)
2. it strips out file names of uploaded images and assigns a random cryptographic string to their name.
3. this causes a headache later with a second loop through and meta data analysis where as we already have this information prior and can work off of it.
4. we can also simplify the code later down the line by combining steps with this new overwritten functionality (meaning the flattening of the folder structure and mapping positions).

hence the overwrite.